### PR TITLE
39 prospect api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1894,6 +1894,11 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
       "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
+    "date-fns": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.24.0.tgz",
+      "integrity": "sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
     "@material-ui/system": "^4.12.1",
     "@reduxjs/toolkit": "^1.6.1",
     "@supabase/supabase-js": "^1.18.1",
+    "date-fns": "^2.24.0",
     "eslint-config-next": "^11.0.1",
     "formik": "^2.2.9",
     "next": "^11.0.1",
     "ramda": "^0.27.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "swr": "^0.5.6",
-    "react-redux": "^7.2.4"
+    "react-redux": "^7.2.4",
+    "swr": "^0.5.6"
   },
   "devDependencies": {
     "eslint": "^7.26.0",

--- a/src/modules/ministers.js
+++ b/src/modules/ministers.js
@@ -7,17 +7,17 @@ export function getMinisters(query) {
 }
 
 export function createMinister(minister) {
-  return client.post('api/ministers', minister);
+  return client.post('/api/ministers', minister);
 }
 
 export function getMinisterById(id) {
-  return client.get(`api/ministers/${id}`);
+  return client.get(`/api/ministers/${id}`);
 }
 
 export function updateMinisterById(id, minister) {
-  return client.put(`api/ministers/${id}`, minister);
+  return client.put(`/api/ministers/${id}`, minister);
 }
 
 export function deleteMinisterById(id) {
-  return client.delete(`api/ministers/${id}`);
+  return client.delete(`/api/ministers/${id}`);
 }

--- a/src/modules/partners.js
+++ b/src/modules/partners.js
@@ -15,17 +15,17 @@ export function getPartners(query) {
 }
 
 export function createPartner(partner) {
-  return client.post('api/partners', partner);
+  return client.post('/api/partners', partner);
 }
 
 export function getPartnerById(id) {
-  return client.get(`api/partners/${id}`);
+  return client.get(`/api/partners/${id}`);
 }
 
 export function updatePartnerById(id, partner) {
-  return client.put(`api/partners/${id}`, partner);
+  return client.put(`/api/partners/${id}`, partner);
 }
 
 export function deletePartnerById(id) {
-  return client.delete(`api/partners/${id}`);
+  return client.delete(`/api/partners/${id}`);
 }

--- a/src/pages/[userId]/prospects.js
+++ b/src/pages/[userId]/prospects.js
@@ -1,14 +1,12 @@
-import { useRouter } from 'next/router';
-import styled from '@emotion/styled';
-import {
-  pipe, join, length, path, prop, ifElse,
-} from 'ramda';
-import { format } from 'date-fns';
-import add from 'date-fns/add';
-import Grid from '@material-ui/core/Grid';
-import { DesktopOnly, MobileOnly } from '../../components/MediaQuery';
-import { getProspects } from '../../modules/partners';
-import { getMinisterById } from '../../modules/ministers';
+import { useRouter } from "next/router";
+import styled from "@emotion/styled";
+import { pipe, join, length, path, prop, ifElse } from "ramda";
+import { format } from "date-fns";
+import add from "date-fns/add";
+import Grid from "@material-ui/core/Grid";
+import { DesktopOnly, MobileOnly } from "../../components/MediaQuery";
+import { getProspects } from "../../modules/partners";
+import { getMinisterById } from "../../modules/ministers";
 
 export default function Prospects() {
   const router = useRouter();
@@ -23,11 +21,11 @@ export default function Prospects() {
     isLoading: isLoadingUser,
     error: userError,
   } = getMinisterById(`${userId}`);
-  const joinOtherMinisters = pipe(prop('other_ministers'), join(', '));
+  const joinOtherMinisters = pipe(prop("other_ministers"), join(", "));
   const getPreferredName = ifElse(
-    prop('nickname'),
-    prop('nickname'),
-    path(['aliases', 0]),
+    prop("nickname"),
+    prop("nickname"),
+    path(["aliases", 0])
   );
   const Container = styled.div`
     h1 {
@@ -70,7 +68,7 @@ export default function Prospects() {
     <Container>
       {isLoadingUser && <h1>Loading user...</h1>}
       {user && <h1>Prospects for {user.first_name}</h1>}
-      <Grid container spacing={0} className="columns">
+      <Grid container spacing={0} className='columns'>
         <Grid item md={2} xs={3}>
           <h4>Name</h4>
         </Grid>
@@ -90,40 +88,40 @@ export default function Prospects() {
         </Grid>
       </Grid>
       {isLoadingProspects && <h1>Loading data...</h1>}
-      {prospects
-        && prospects.map((prospect) => (
+      {prospects &&
+        prospects.map((prospect) => (
           <Grid
             container
             spacing={1}
             key={prospect.id}
-            className="striped columns"
+            className='striped columns'
           >
             <Grid item md={2} xs={3}>
               <p>{getPreferredName(prospect)}</p>
             </Grid>
             <Grid item md={2} xs={3}>
-              <p>{prop('status', prospect)}</p>
+              <p>{prop("status", prospect)}</p>
             </Grid>
             <Grid item md={2} xs={3}>
               <p>
                 {/* Days are showing a day behind what is in the DB. Adding a day to resolve it. */}
                 {format(
-                  add(new Date(prop('last_contacted', prospect)), { days: 1 }),
-                  'LLLL eo',
+                  add(new Date(prop("last_contacted", prospect)), { days: 1 }),
+                  "MMM eo"
                 )}
               </p>
             </Grid>
             <DesktopOnly>
               <Grid item md={3}>
-                <p>{path(['notes', 'prospect', '0'], prospect)}</p>
+                <p>{path(["notes", "prospect", "0"], prospect)}</p>
               </Grid>
             </DesktopOnly>
             <Grid item md={2} xs={3}>
               <p>
                 <DesktopOnly>{joinOtherMinisters(prospect)}</DesktopOnly>
                 <MobileOnly>
-                  <span className="numbers">
-                    {pipe(prop('other_ministers'), length)(prospect)}
+                  <span className='numbers'>
+                    {pipe(prop("other_ministers"), length)(prospect)}
                   </span>
                 </MobileOnly>
               </p>

--- a/src/pages/[userId]/prospects.js
+++ b/src/pages/[userId]/prospects.js
@@ -1,12 +1,14 @@
-import { useRouter } from "next/router";
-import styled from "@emotion/styled";
-import { pipe, join, length, path, prop, ifElse } from "ramda";
-import { format } from "date-fns";
-import add from "date-fns/add";
-import Grid from "@material-ui/core/Grid";
-import { DesktopOnly, MobileOnly } from "../../components/MediaQuery";
-import { getProspects } from "../../modules/partners";
-import { getMinisterById } from "../../modules/ministers";
+import { useRouter } from 'next/router';
+import styled from '@emotion/styled';
+import {
+  pipe, join, length, path, prop, ifElse,
+} from 'ramda';
+import { format } from 'date-fns';
+import add from 'date-fns/add';
+import Grid from '@material-ui/core/Grid';
+import { DesktopOnly, MobileOnly } from '../../components/MediaQuery';
+import { getProspects } from '../../modules/partners';
+import { getMinisterById } from '../../modules/ministers';
 
 export default function Prospects() {
   const router = useRouter();
@@ -21,11 +23,11 @@ export default function Prospects() {
     isLoading: isLoadingUser,
     error: userError,
   } = getMinisterById(`${userId}`);
-  const joinOtherMinisters = pipe(prop("other_ministers"), join(", "));
+  const joinOtherMinisters = pipe(prop('other_ministers'), join(', '));
   const getPreferredName = ifElse(
-    prop("nickname"),
-    prop("nickname"),
-    path(["aliases", 0])
+    prop('nickname'),
+    prop('nickname'),
+    path(['aliases', 0]),
   );
   const Container = styled.div`
     h1 {
@@ -68,7 +70,7 @@ export default function Prospects() {
     <Container>
       {isLoadingUser && <h1>Loading user...</h1>}
       {user && <h1>Prospects for {user.first_name}</h1>}
-      <Grid container spacing={0} className='columns'>
+      <Grid container spacing={0} className="columns">
         <Grid item md={2} xs={3}>
           <h4>Name</h4>
         </Grid>
@@ -88,40 +90,40 @@ export default function Prospects() {
         </Grid>
       </Grid>
       {isLoadingProspects && <h1>Loading data...</h1>}
-      {prospects &&
-        prospects.map((prospect) => (
+      {prospects
+        && prospects.map((prospect) => (
           <Grid
             container
             spacing={1}
             key={prospect.id}
-            className='striped columns'
+            className="striped columns"
           >
             <Grid item md={2} xs={3}>
               <p>{getPreferredName(prospect)}</p>
             </Grid>
             <Grid item md={2} xs={3}>
-              <p>{prop("status", prospect)}</p>
+              <p>{prop('status', prospect)}</p>
             </Grid>
             <Grid item md={2} xs={3}>
               <p>
                 {/* Days are showing a day behind what is in the DB. Adding a day to resolve it. */}
                 {format(
-                  add(new Date(prop("last_contacted", prospect)), { days: 1 }),
-                  "MMM eo"
+                  add(new Date(prop('last_contacted', prospect)), { days: 1 }),
+                  'MMM eo',
                 )}
               </p>
             </Grid>
             <DesktopOnly>
               <Grid item md={3}>
-                <p>{path(["notes", "prospect", "0"], prospect)}</p>
+                <p>{path(['notes', 'prospect', '0'], prospect)}</p>
               </Grid>
             </DesktopOnly>
             <Grid item md={2} xs={3}>
               <p>
                 <DesktopOnly>{joinOtherMinisters(prospect)}</DesktopOnly>
                 <MobileOnly>
-                  <span className='numbers'>
-                    {pipe(prop("other_ministers"), length)(prospect)}
+                  <span className="numbers">
+                    {pipe(prop('other_ministers'), length)(prospect)}
                   </span>
                 </MobileOnly>
               </p>

--- a/src/pages/[userId]/prospects.js
+++ b/src/pages/[userId]/prospects.js
@@ -1,14 +1,22 @@
-import { useRouter } from "next/router";
-import styled from "@emotion/styled";
-import { pipe, join, length, path, prop } from "ramda";
-import Grid from "@material-ui/core/Grid";
-import { DesktopOnly, MobileOnly } from "../../components/MediaQuery";
-import { getProspects } from "../../modules/partners";
+import { useRouter } from 'next/router';
+import styled from '@emotion/styled';
+import {
+  pipe, join, length, path, prop, ifElse,
+} from 'ramda';
+import Grid from '@material-ui/core/Grid';
+import { DesktopOnly, MobileOnly } from '../../components/MediaQuery';
+import { getProspects } from '../../modules/partners';
 
 export default function Prospects() {
   const router = useRouter();
   const { userId } = router.query;
-  const joinOtherMinisters = pipe(prop("other_ministers"), join(", "));
+  const { data: prospects, isLoading, error } = getProspects(userId);
+  const joinOtherMinisters = pipe(prop('other_ministers'), join(', '));
+  const getPreferredName = ifElse(
+    prop('nickname'),
+    prop('nickname'),
+    path(['aliases', 0]),
+  );
   const Container = styled.div`
     h1 {
       margin-left: 1rem;
@@ -46,52 +54,10 @@ export default function Prospects() {
     }
   `;
 
-  const { data: prospects, isLoading, error } = getProspects(userId);
-
-  // const prospects = [
-  //   {
-  //     id: 1,
-  //     names: ["Jon smith"],
-  //     preferred_name: null,
-  //     status: "contacted",
-  //     last_contacted: "07/13",
-  //     notes: ["Meeting up on 08/27", "Left a voicemail", "Emailed"],
-  //     other_ministers: ["Reagann Smith", "Ryan Bristow"],
-  //   },
-  //   {
-  //     id: 2,
-  //     names: ["Matt Clark"],
-  //     preferred_name: null,
-  //     status: "pledged, no amount",
-  //     last_contacted: "06/21",
-  //     notes: ["Need to follow up"],
-  //     other_ministers: ["Danielle Clark"],
-  //   },
-  //   {
-  //     id: 3,
-  //     names: ["Mitchell Pavel"],
-  //     preferred_name: null,
-  //     status: "contacted",
-  //     last_contacted: "06/30",
-  //     notes: ["Wants to donate, partnering with the wife"],
-  //     other_ministers: [],
-  //   },
-  //   {
-  //     id: 4,
-  //     names: ["Bob Chin"],
-  //     preferred_name: null,
-  //     status: "No answer",
-  //     last_contacted: "07/01",
-  //     notes: ["Left voicemail", "Attempted contact; No response."],
-  //     other_ministers: [],
-  //   },
-  // ];
-
   return (
     <Container>
-      {prospects && console.log(prospects)}
       <h1>Prospects for {userId}</h1>
-      <Grid container spacing={0} className='columns'>
+      <Grid container spacing={0} className="columns">
         <Grid item md={2} xs={3}>
           <h4>Name</h4>
         </Grid>
@@ -111,34 +77,34 @@ export default function Prospects() {
         </Grid>
       </Grid>
       {isLoading && <h1>Loading data...</h1>}
-      {prospects &&
-        prospects.map((prospect) => (
+      {prospects
+        && prospects.map((prospect) => (
           <Grid
             container
             spacing={1}
             key={prospect.id}
-            className='striped columns'
+            className="striped columns"
           >
             <Grid item md={2} xs={3}>
-              <p>{path(["names", "0"], prospect)}</p>
+              <p>{getPreferredName(prospect)}</p>
             </Grid>
             <Grid item md={2} xs={3}>
-              <p>{prop("status", prospect)}</p>
+              <p>{prop('status', prospect)}</p>
             </Grid>
             <Grid item md={2} xs={3}>
-              <p>{prop("last_contacted", prospect)}</p>
+              <p>{prop('last_contacted', prospect)}</p>
             </Grid>
             <DesktopOnly>
               <Grid item md={3}>
-                <p>{path(["notes", "0"], prospect)}</p>
+                <p>{path(['notes', 'prospect'], prospect)}</p>
               </Grid>
             </DesktopOnly>
             <Grid item md={2} xs={3}>
               <p>
                 <DesktopOnly>{joinOtherMinisters(prospect)}</DesktopOnly>
                 <MobileOnly>
-                  <span className='numbers'>
-                    {pipe(prop("other_ministers"), length)(prospect)}
+                  <span className="numbers">
+                    {pipe(prop('other_ministers'), length)(prospect)}
                   </span>
                 </MobileOnly>
               </p>

--- a/src/pages/[userId]/prospects.js
+++ b/src/pages/[userId]/prospects.js
@@ -1,19 +1,21 @@
-import { useRouter } from "next/router";
-import styled from "@emotion/styled";
-import { pipe, join, length, path, prop, ifElse } from "ramda";
-import Grid from "@material-ui/core/Grid";
-import { DesktopOnly, MobileOnly } from "../../components/MediaQuery";
-import { getProspects } from "../../modules/partners";
+import { useRouter } from 'next/router';
+import styled from '@emotion/styled';
+import {
+  pipe, join, length, path, prop, ifElse,
+} from 'ramda';
+import Grid from '@material-ui/core/Grid';
+import { DesktopOnly, MobileOnly } from '../../components/MediaQuery';
+import { getProspects } from '../../modules/partners';
 
 export default function Prospects() {
   const router = useRouter();
   const { userId } = router.query;
   const { data: prospects, isLoading, error } = getProspects(userId);
-  const joinOtherMinisters = pipe(prop("other_ministers"), join(", "));
+  const joinOtherMinisters = pipe(prop('other_ministers'), join(', '));
   const getPreferredName = ifElse(
-    prop("nickname"),
-    prop("nickname"),
-    path(["aliases", 0])
+    prop('nickname'),
+    prop('nickname'),
+    path(['aliases', 0]),
   );
   const Container = styled.div`
     h1 {
@@ -55,7 +57,7 @@ export default function Prospects() {
   return (
     <Container>
       <h1>Prospects for {userId}</h1>
-      <Grid container spacing={0} className='columns'>
+      <Grid container spacing={0} className="columns">
         <Grid item md={2} xs={3}>
           <h4>Name</h4>
         </Grid>
@@ -75,34 +77,34 @@ export default function Prospects() {
         </Grid>
       </Grid>
       {isLoading && <h1>Loading data...</h1>}
-      {prospects &&
-        prospects.map((prospect) => (
+      {prospects
+        && prospects.map((prospect) => (
           <Grid
             container
             spacing={1}
             key={prospect.id}
-            className='striped columns'
+            className="striped columns"
           >
             <Grid item md={2} xs={3}>
               <p>{getPreferredName(prospect)}</p>
             </Grid>
             <Grid item md={2} xs={3}>
-              <p>{prop("status", prospect)}</p>
+              <p>{prop('status', prospect)}</p>
             </Grid>
             <Grid item md={2} xs={3}>
-              <p>{prop("last_contacted", prospect)}</p>
+              <p>{prop('last_contacted', prospect)}</p>
             </Grid>
             <DesktopOnly>
               <Grid item md={3}>
-                <p>{path(["notes", "prospect", "0"], prospect)}</p>
+                <p>{path(['notes', 'prospect', '0'], prospect)}</p>
               </Grid>
             </DesktopOnly>
             <Grid item md={2} xs={3}>
               <p>
                 <DesktopOnly>{joinOtherMinisters(prospect)}</DesktopOnly>
                 <MobileOnly>
-                  <span className='numbers'>
-                    {pipe(prop("other_ministers"), length)(prospect)}
+                  <span className="numbers">
+                    {pipe(prop('other_ministers'), length)(prospect)}
                   </span>
                 </MobileOnly>
               </p>

--- a/src/pages/[userId]/prospects.js
+++ b/src/pages/[userId]/prospects.js
@@ -3,12 +3,55 @@ import styled from '@emotion/styled';
 import {
   pipe, join, length, path, prop, ifElse,
 } from 'ramda';
-import { format } from 'date-fns';
-import add from 'date-fns/add';
+import { format, parse } from 'date-fns';
 import Grid from '@material-ui/core/Grid';
 import { DesktopOnly, MobileOnly } from '../../components/MediaQuery';
 import { getProspects } from '../../modules/partners';
 import { getMinisterById } from '../../modules/ministers';
+
+const joinOtherMinisters = pipe(prop('other_ministers'), join(', '));
+const getPreferredName = ifElse(
+  prop('nickname'),
+  prop('nickname'),
+  path(['aliases', 0]),
+);
+
+const Container = styled.div`
+  h1 {
+    margin-left: 1rem;
+  }
+
+  .columns {
+    padding-left: 1rem;
+  }
+
+  .striped:nth-of-type(2n) {
+    background: #f5f5f5;
+  }
+
+  .numbers {
+    display: block;
+    width: 25px;
+    height: 25px;
+    text-align: center;
+    background-color: red;
+    color: white;
+    border-radius: 50%;
+    margin: 0 auto;
+  }
+
+  @media (max-width: 960px) {
+    text-align: center;
+
+    h1 {
+      margin-left: 0;
+    }
+
+    .columns {
+      padding: 0;
+    }
+  }
+`;
 
 export default function Prospects() {
   const router = useRouter();
@@ -23,52 +66,11 @@ export default function Prospects() {
     isLoading: isLoadingUser,
     error: userError,
   } = getMinisterById(`${userId}`);
-  const joinOtherMinisters = pipe(prop('other_ministers'), join(', '));
-  const getPreferredName = ifElse(
-    prop('nickname'),
-    prop('nickname'),
-    path(['aliases', 0]),
-  );
-  const Container = styled.div`
-    h1 {
-      margin-left: 1rem;
-    }
-
-    .columns {
-      padding-left: 1rem;
-    }
-
-    .striped:nth-of-type(2n) {
-      background: #f5f5f5;
-    }
-
-    .numbers {
-      display: block;
-      width: 25px;
-      height: 25px;
-      text-align: center;
-      background-color: red;
-      color: white;
-      border-radius: 50%;
-      margin: 0 auto;
-    }
-
-    @media (max-width: 960px) {
-      text-align: center;
-
-      h1 {
-        margin-left: 0;
-      }
-
-      .columns {
-        padding: 0;
-      }
-    }
-  `;
 
   return (
     <Container>
       {isLoadingUser && <h1>Loading user...</h1>}
+      {userError && <h1>Error loading minister information...</h1>}
       {user && <h1>Prospects for {user.first_name}</h1>}
       <Grid container spacing={0} className="columns">
         <Grid item md={2} xs={3}>
@@ -90,6 +92,7 @@ export default function Prospects() {
         </Grid>
       </Grid>
       {isLoadingProspects && <h1>Loading data...</h1>}
+      {prospectsError && <h1>Error loading prospects...</h1>}
       {prospects
         && prospects.map((prospect) => (
           <Grid
@@ -106,10 +109,13 @@ export default function Prospects() {
             </Grid>
             <Grid item md={2} xs={3}>
               <p>
-                {/* Days are showing a day behind what is in the DB. Adding a day to resolve it. */}
                 {format(
-                  add(new Date(prop('last_contacted', prospect)), { days: 1 }),
-                  'MMM eo',
+                  parse(
+                    prop('last_contacted', prospect),
+                    'yyyy-MM-dd',
+                    new Date(),
+                  ),
+                  'MMM do',
                 )}
               </p>
             </Grid>

--- a/src/pages/[userId]/prospects.js
+++ b/src/pages/[userId]/prospects.js
@@ -65,12 +65,12 @@ export default function Prospects() {
     data: user,
     isLoading: isLoadingUser,
     error: userError,
-  } = getMinisterById(`${userId}`);
+  } = getMinisterById(userId);
 
   return (
     <Container>
-      {isLoadingUser && <h1>Loading user...</h1>}
-      {userError && <h1>Error loading minister information...</h1>}
+      {isLoadingUser && <p>Loading user...</p>}
+      {userError && <p>Error loading minister information...</p>}
       {user && <h1>Prospects for {user.first_name}</h1>}
       <Grid container spacing={0} className="columns">
         <Grid item md={2} xs={3}>
@@ -91,8 +91,9 @@ export default function Prospects() {
           <h4>Other Ministers</h4>
         </Grid>
       </Grid>
-      {isLoadingProspects && <h1>Loading data...</h1>}
-      {prospectsError && <h1>Error loading prospects...</h1>}
+      {isLoadingProspects && <p>Loading data...</p>}
+      {prospectsError && <p>Error loading prospects...</p>}
+      {prospects && prospects.length === 0 && <p>You have no current prospects.</p>}
       {prospects
         && prospects.map((prospect) => (
           <Grid

--- a/src/pages/[userId]/prospects.js
+++ b/src/pages/[userId]/prospects.js
@@ -1,15 +1,14 @@
-import { useRouter } from 'next/router';
-import styled from '@emotion/styled';
-import {
-  pipe, join, length, path, prop,
-} from 'ramda';
-import Grid from '@material-ui/core/Grid';
-import { DesktopOnly, MobileOnly } from 'components/MediaQuery';
+import { useRouter } from "next/router";
+import styled from "@emotion/styled";
+import { pipe, join, length, path, prop } from "ramda";
+import Grid from "@material-ui/core/Grid";
+import { DesktopOnly, MobileOnly } from "../../components/MediaQuery";
+import { getProspects } from "../../modules/partners";
 
 export default function Prospects() {
   const router = useRouter();
   const { userId } = router.query;
-  const joinOtherMinisters = pipe(prop('other_ministers'), join(', '));
+  const joinOtherMinisters = pipe(prop("other_ministers"), join(", "));
   const Container = styled.div`
     h1 {
       margin-left: 1rem;
@@ -47,49 +46,52 @@ export default function Prospects() {
     }
   `;
 
-  const prospects = [
-    {
-      id: 1,
-      names: ['Jon smith'],
-      preferred_name: null,
-      status: 'contacted',
-      last_contacted: '07/13',
-      notes: ['Meeting up on 08/27', 'Left a voicemail', 'Emailed'],
-      other_ministers: ['Reagann Smith', 'Ryan Bristow'],
-    },
-    {
-      id: 2,
-      names: ['Matt Clark'],
-      preferred_name: null,
-      status: 'pledged, no amount',
-      last_contacted: '06/21',
-      notes: ['Need to follow up'],
-      other_ministers: ['Danielle Clark'],
-    },
-    {
-      id: 3,
-      names: ['Mitchell Pavel'],
-      preferred_name: null,
-      status: 'contacted',
-      last_contacted: '06/30',
-      notes: ['Wants to donate, partnering with the wife'],
-      other_ministers: [],
-    },
-    {
-      id: 4,
-      names: ['Bob Chin'],
-      preferred_name: null,
-      status: 'No answer',
-      last_contacted: '07/01',
-      notes: ['Left voicemail', 'Attempted contact; No response.'],
-      other_ministers: [],
-    },
-  ];
+  const { data: prospects, isLoading, error } = getProspects(userId);
+
+  // const prospects = [
+  //   {
+  //     id: 1,
+  //     names: ["Jon smith"],
+  //     preferred_name: null,
+  //     status: "contacted",
+  //     last_contacted: "07/13",
+  //     notes: ["Meeting up on 08/27", "Left a voicemail", "Emailed"],
+  //     other_ministers: ["Reagann Smith", "Ryan Bristow"],
+  //   },
+  //   {
+  //     id: 2,
+  //     names: ["Matt Clark"],
+  //     preferred_name: null,
+  //     status: "pledged, no amount",
+  //     last_contacted: "06/21",
+  //     notes: ["Need to follow up"],
+  //     other_ministers: ["Danielle Clark"],
+  //   },
+  //   {
+  //     id: 3,
+  //     names: ["Mitchell Pavel"],
+  //     preferred_name: null,
+  //     status: "contacted",
+  //     last_contacted: "06/30",
+  //     notes: ["Wants to donate, partnering with the wife"],
+  //     other_ministers: [],
+  //   },
+  //   {
+  //     id: 4,
+  //     names: ["Bob Chin"],
+  //     preferred_name: null,
+  //     status: "No answer",
+  //     last_contacted: "07/01",
+  //     notes: ["Left voicemail", "Attempted contact; No response."],
+  //     other_ministers: [],
+  //   },
+  // ];
 
   return (
     <Container>
+      {prospects && console.log(prospects)}
       <h1>Prospects for {userId}</h1>
-      <Grid container spacing={0} className="columns">
+      <Grid container spacing={0} className='columns'>
         <Grid item md={2} xs={3}>
           <h4>Name</h4>
         </Grid>
@@ -108,39 +110,41 @@ export default function Prospects() {
           <h4>Other Ministers</h4>
         </Grid>
       </Grid>
-      {prospects.map((prospect) => (
-        <Grid
-          container
-          spacing={1}
-          key={prospect.id}
-          className="striped columns"
-        >
-          <Grid item md={2} xs={3}>
-            <p>{path(['names', '0'], prospect)}</p>
-          </Grid>
-          <Grid item md={2} xs={3}>
-            <p>{prop('status', prospect)}</p>
-          </Grid>
-          <Grid item md={2} xs={3}>
-            <p>{prop('last_contacted', prospect)}</p>
-          </Grid>
-          <DesktopOnly>
-            <Grid item md={3}>
-              <p>{path(['notes', '0'], prospect)}</p>
+      {isLoading && <h1>Loading data...</h1>}
+      {prospects &&
+        prospects.map((prospect) => (
+          <Grid
+            container
+            spacing={1}
+            key={prospect.id}
+            className='striped columns'
+          >
+            <Grid item md={2} xs={3}>
+              <p>{path(["names", "0"], prospect)}</p>
             </Grid>
-          </DesktopOnly>
-          <Grid item md={2} xs={3}>
-            <p>
-              <DesktopOnly>{joinOtherMinisters(prospect)}</DesktopOnly>
-              <MobileOnly>
-                <span className="numbers">
-                  {pipe(prop('other_ministers'), length)(prospect)}
-                </span>
-              </MobileOnly>
-            </p>
+            <Grid item md={2} xs={3}>
+              <p>{prop("status", prospect)}</p>
+            </Grid>
+            <Grid item md={2} xs={3}>
+              <p>{prop("last_contacted", prospect)}</p>
+            </Grid>
+            <DesktopOnly>
+              <Grid item md={3}>
+                <p>{path(["notes", "0"], prospect)}</p>
+              </Grid>
+            </DesktopOnly>
+            <Grid item md={2} xs={3}>
+              <p>
+                <DesktopOnly>{joinOtherMinisters(prospect)}</DesktopOnly>
+                <MobileOnly>
+                  <span className='numbers'>
+                    {pipe(prop("other_ministers"), length)(prospect)}
+                  </span>
+                </MobileOnly>
+              </p>
+            </Grid>
           </Grid>
-        </Grid>
-      ))}
+        ))}
     </Container>
   );
 }

--- a/src/pages/[userId]/prospects.js
+++ b/src/pages/[userId]/prospects.js
@@ -1,21 +1,19 @@
-import { useRouter } from 'next/router';
-import styled from '@emotion/styled';
-import {
-  pipe, join, length, path, prop, ifElse,
-} from 'ramda';
-import Grid from '@material-ui/core/Grid';
-import { DesktopOnly, MobileOnly } from '../../components/MediaQuery';
-import { getProspects } from '../../modules/partners';
+import { useRouter } from "next/router";
+import styled from "@emotion/styled";
+import { pipe, join, length, path, prop, ifElse } from "ramda";
+import Grid from "@material-ui/core/Grid";
+import { DesktopOnly, MobileOnly } from "../../components/MediaQuery";
+import { getProspects } from "../../modules/partners";
 
 export default function Prospects() {
   const router = useRouter();
   const { userId } = router.query;
   const { data: prospects, isLoading, error } = getProspects(userId);
-  const joinOtherMinisters = pipe(prop('other_ministers'), join(', '));
+  const joinOtherMinisters = pipe(prop("other_ministers"), join(", "));
   const getPreferredName = ifElse(
-    prop('nickname'),
-    prop('nickname'),
-    path(['aliases', 0]),
+    prop("nickname"),
+    prop("nickname"),
+    path(["aliases", 0])
   );
   const Container = styled.div`
     h1 {
@@ -57,7 +55,7 @@ export default function Prospects() {
   return (
     <Container>
       <h1>Prospects for {userId}</h1>
-      <Grid container spacing={0} className="columns">
+      <Grid container spacing={0} className='columns'>
         <Grid item md={2} xs={3}>
           <h4>Name</h4>
         </Grid>
@@ -77,34 +75,34 @@ export default function Prospects() {
         </Grid>
       </Grid>
       {isLoading && <h1>Loading data...</h1>}
-      {prospects
-        && prospects.map((prospect) => (
+      {prospects &&
+        prospects.map((prospect) => (
           <Grid
             container
             spacing={1}
             key={prospect.id}
-            className="striped columns"
+            className='striped columns'
           >
             <Grid item md={2} xs={3}>
               <p>{getPreferredName(prospect)}</p>
             </Grid>
             <Grid item md={2} xs={3}>
-              <p>{prop('status', prospect)}</p>
+              <p>{prop("status", prospect)}</p>
             </Grid>
             <Grid item md={2} xs={3}>
-              <p>{prop('last_contacted', prospect)}</p>
+              <p>{prop("last_contacted", prospect)}</p>
             </Grid>
             <DesktopOnly>
               <Grid item md={3}>
-                <p>{path(['notes', 'prospect'], prospect)}</p>
+                <p>{path(["notes", "prospect", "0"], prospect)}</p>
               </Grid>
             </DesktopOnly>
             <Grid item md={2} xs={3}>
               <p>
                 <DesktopOnly>{joinOtherMinisters(prospect)}</DesktopOnly>
                 <MobileOnly>
-                  <span className="numbers">
-                    {pipe(prop('other_ministers'), length)(prospect)}
+                  <span className='numbers'>
+                    {pipe(prop("other_ministers"), length)(prospect)}
                   </span>
                 </MobileOnly>
               </p>

--- a/src/pages/api/connections/pledges/[ministerId].js
+++ b/src/pages/api/connections/pledges/[ministerId].js
@@ -1,6 +1,5 @@
 import router from 'modules/router';
 import supabase from 'modules/supabase';
-import { isEmpty } from 'ramda';
 
 const api = {
   /* GET pledges for minister by ID

--- a/src/pages/api/connections/pledges/[ministerId].js
+++ b/src/pages/api/connections/pledges/[ministerId].js
@@ -47,9 +47,7 @@ const api = {
       .from('pledges')
       .select()
       .match({ minister_id: ministerId });
-    if (data && isEmpty(data)) {
-      res.status(404).send(`No pledges found for minister with ID ${ministerId}.`);
-    } else if (error) {
+    if (error) {
       res.status(400).send(error);
     } else {
       res.status(200).json(data);

--- a/src/pages/api/connections/prospects/[ministerId].js
+++ b/src/pages/api/connections/prospects/[ministerId].js
@@ -1,6 +1,5 @@
 import router from 'modules/router';
 import supabase from 'modules/supabase';
-import { isEmpty } from 'ramda';
 
 const api = {
   /* GET prospects for minister by ID

--- a/src/pages/api/connections/prospects/[ministerId].js
+++ b/src/pages/api/connections/prospects/[ministerId].js
@@ -46,9 +46,7 @@ const api = {
       .from('prospects') // sql view
       .select()
       .match({ minister_id: ministerId });
-    if (data && isEmpty(data)) {
-      res.status(404).send(`No prospects found for minister with ID ${ministerId}.`);
-    } else if (error) {
+    if (error) {
       res.status(400).send(error);
     } else {
       res.status(200).json(data);


### PR DESCRIPTION
closes #39
Changes:
- Switched from Dummy Data to the API 
- Setup Ramda function to grab the name (Nickname vs. Aliases) 
- Setup Ramda function to get notes from the prospects section of notes
- Setup loading checks to avoid errors when loading 

Questions:
- Is there a better way to get the notes from prospects since it is nested?
- Right now, if the ID does not exist no data or messaging is presented. Do we want to handle that in a redirect with a 'flash' message, or handle it on the ministers page directly?
