### PR TITLE
42 partners initial load

### DIFF
--- a/src/components/LoginButton.js
+++ b/src/components/LoginButton.js
@@ -1,6 +1,5 @@
 import { Button } from '@material-ui/core';
 import { styled } from '@material-ui/core/styles';
-import React from 'react';
 import { path } from 'ramda';
 import { useSelector, useDispatch } from 'react-redux';
 import { login, logout } from 'modules/store/authorization';

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -1,10 +1,8 @@
 import { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
-import {
-  IconButton,
-  SwipeableDrawer,
-} from '@material-ui/core';
+import { IconButton, SwipeableDrawer } from '@material-ui/core';
 import { Menu, ChevronLeft } from '@material-ui/icons';
 import styled from '@emotion/styled';
 import {
@@ -14,12 +12,14 @@ import {
   prop,
   split,
 } from 'ramda';
+
 import { DesktopOnly, MobileOnly } from 'components/MediaQuery';
 import MenuButtons from 'components/MenuButtons';
+import { updatePartners, emptyPartners } from 'modules/store/partners';
+import { updateMinisters, emptyMinisters } from 'modules/store/ministers';
+import { getPartners } from 'modules/partners';
+import { getMinisters } from 'modules/ministers';
 import colors from 'styles/colors';
-import { useSelector, useDispatch } from 'react-redux';
-import { updatePartners } from '../modules/store/partners';
-import { getPartners } from '../modules/partners';
 
 const Header = styled.div`
   width: 100%;
@@ -62,21 +62,36 @@ export default function Wrapper({ children }) {
     // isLoading: isLoadingPartnersList,
     error: partnersListError,
   } = getPartners();
+  const {
+    data: ministersList,
+    // isLoading: isLoadingMinistersList,
+    error: ministersListError,
+  } = getMinisters();
 
   useEffect(() => {
     if (isAuthorized && partnersList) {
       dispatch(updatePartners(partnersList));
     } else if (!isAuthorized) {
-      dispatch(updatePartners(null));
-      // router.replace('/login');
+      dispatch(emptyPartners());
     }
   }, [isAuthorized, partnersList]);
+
+  useEffect(() => {
+    if (isAuthorized && ministersList) {
+      dispatch(updateMinisters(ministersList));
+    } else if (!isAuthorized) {
+      dispatch(emptyMinisters());
+    }
+  }, [isAuthorized, ministersList]);
 
   useEffect(() => {
     if (partnersListError) {
       console.error('Error loading partners list:', partnersListError);
     }
-  }, [partnersListError]);
+    if (ministersListError) {
+      console.error('Error loading ministers list:', ministersListError);
+    }
+  }, [partnersListError, ministersListError]);
 
   return (
     <div>

--- a/src/modules/ministers.js
+++ b/src/modules/ministers.js
@@ -1,9 +1,7 @@
 import client from 'modules/api-client';
 
-export function getMinisters(query) {
-  const searchParams = new URLSearchParams(query);
-  const queryString = `?${searchParams.toString()}`;
-  return client.get(`/api/ministers${query && queryString}`);
+export function getMinisters() {
+  return client.get('/api/ministers');
 }
 
 export function createMinister(minister) {

--- a/src/modules/partners.js
+++ b/src/modules/partners.js
@@ -8,10 +8,8 @@ export function getPledges(ministerId) {
   return client.get(`/api/connections/pledges/${ministerId}`);
 }
 
-export function getPartners(query) {
-  const searchParams = new URLSearchParams(query);
-  const queryString = `?${searchParams.toString()}`;
-  return client.get(`/api/partners${query && queryString}`);
+export function getPartners() {
+  return client.get('/api/partners');
 }
 
 export function createPartner(partner) {

--- a/src/modules/store/index.js
+++ b/src/modules/store/index.js
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authorizationReducer from './authorization';
 import partnersReducer from './partners';
+import ministersReducer from './ministers';
 
 export default configureStore({
   reducer: {
     authorization: authorizationReducer,
     partners: partnersReducer,
+    ministers: ministersReducer,
   },
 });

--- a/src/modules/store/index.js
+++ b/src/modules/store/index.js
@@ -1,8 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authorizationReducer from './authorization';
+import partnersReducer from './partners';
 
 export default configureStore({
   reducer: {
     authorization: authorizationReducer,
+    partners: partnersReducer,
   },
 });

--- a/src/modules/store/ministers.js
+++ b/src/modules/store/ministers.js
@@ -2,21 +2,21 @@
 // param reassign can be used bc redux toolkit handles that under the hood
 import { createSlice } from '@reduxjs/toolkit';
 
-export const partnersSlice = createSlice({
-  name: 'partners',
+export const ministersSlice = createSlice({
+  name: 'ministers',
   initialState: {
     list: [],
   },
   reducers: {
-    updatePartners: (state, action) => {
+    updateMinisters: (state, action) => {
       state.list = action.payload;
     },
-    emptyPartners: (state) => {
+    emptyMinisters: (state) => {
       state.list = [];
     },
   },
 });
 
-export const { updatePartners, emptyPartners } = partnersSlice.actions;
+export const { updateMinisters, emptyMinisters } = ministersSlice.actions;
 
-export default partnersSlice.reducer;
+export default ministersSlice.reducer;

--- a/src/modules/store/partners.js
+++ b/src/modules/store/partners.js
@@ -1,0 +1,19 @@
+/* eslint-disable no-param-reassign */
+// param reassign can be used bc redux toolkit handles that under the hood
+import { createSlice } from '@reduxjs/toolkit';
+
+export const partnersSlice = createSlice({
+  name: 'partners',
+  initialState: {
+    list: null,
+  },
+  reducers: {
+    updatePartners: (state, action) => {
+      state.list = action.payload;
+    },
+  },
+});
+
+export const { updatePartners } = partnersSlice.actions;
+
+export default partnersSlice.reducer;

--- a/src/pages/api/ministers/index.js
+++ b/src/pages/api/ministers/index.js
@@ -1,6 +1,5 @@
 import router from 'modules/router';
 import supabase from 'modules/supabase';
-import { isEmpty, omit } from 'ramda';
 
 const api = {
   /* GET all ministers

--- a/src/pages/api/ministers/index.js
+++ b/src/pages/api/ministers/index.js
@@ -31,32 +31,13 @@ const api = {
   }
   */
   get: async (req, res) => {
-    let { limit = 15, page = 1 } = req.query;
-    limit = Number(limit);
-    page = Number(page);
-    const query = omit(['limit', 'page'], req.query);
-    const startRange = (page - 1) * limit;
-    const endRange = startRange + limit - 1;
-    const { data, error, count } = await supabase
+    const { data, error } = await supabase
       .from('ministers')
-      .select('*', { count: 'exact' })
-      .match(query)
-      .range(startRange, endRange);
-    if (data && isEmpty(data)) {
-      res.status(404).send(`No ministers found matching query:\n${JSON.stringify(query)}`);
-    } else if (error) {
+      .select();
+    if (error) {
       res.status(400).send(error);
     } else {
-      const pages = Math.ceil(count / limit);
-      const payload = {
-        limit,
-        page,
-        pages,
-        page_count: data.length,
-        total_count: count,
-        data,
-      };
-      res.status(200).json(payload);
+      res.status(200).json(data);
     }
   },
 

--- a/src/pages/api/partners/index.js
+++ b/src/pages/api/partners/index.js
@@ -39,32 +39,42 @@ const api = {
   }
   */
   get: async (req, res) => {
-    let { limit = 15, page = 1 } = req.query;
-    limit = Number(limit);
-    page = Number(page);
-    const query = omit(['limit', 'page'], req.query);
-    const startRange = (page - 1) * limit;
-    const endRange = startRange + limit - 1;
-    const { data, error, count } = await supabase
+    // let { limit = 15, page = 1 } = req.query;
+    // limit = Number(limit);
+    // page = Number(page);
+    // const query = omit(['limit', 'page'], req.query);
+    // const startRange = (page - 1) * limit;
+    // const endRange = startRange + limit - 1;
+    // const { data, error, count } = await supabase
+    //   .from('partners')
+    //   .select('*', { count: 'exact' })
+    //   .match(query)
+    //   .range(startRange, endRange);
+    // if (data && isEmpty(data)) {
+    //   res.status(404).send(`No partners found matching query:\n${JSON.stringify(req.query)}`);
+    // } else if (error) {
+    //   res.status(400).send(error);
+    // } else {
+    //   const pages = Math.ceil(count / limit);
+    //   const payload = {
+    //     limit,
+    //     page,
+    //     pages,
+    //     page_count: data.length,
+    //     total_count: count,
+    //     data,
+    //   };
+    //   res.status(200).json(payload);
+    // }
+    const { data, error } = await supabase
       .from('partners')
-      .select('*', { count: 'exact' })
-      .match(query)
-      .range(startRange, endRange);
+      .select();
     if (data && isEmpty(data)) {
-      res.status(404).send(`No partners found matching query:\n${JSON.stringify(req.query)}`);
+      res.status(404).send('There were no partners found.');
     } else if (error) {
       res.status(400).send(error);
     } else {
-      const pages = Math.ceil(count / limit);
-      const payload = {
-        limit,
-        page,
-        pages,
-        page_count: data.length,
-        total_count: count,
-        data,
-      };
-      res.status(200).json(payload);
+      res.status(200).json(data);
     }
   },
 

--- a/src/pages/api/partners/index.js
+++ b/src/pages/api/partners/index.js
@@ -39,39 +39,10 @@ const api = {
   }
   */
   get: async (req, res) => {
-    // let { limit = 15, page = 1 } = req.query;
-    // limit = Number(limit);
-    // page = Number(page);
-    // const query = omit(['limit', 'page'], req.query);
-    // const startRange = (page - 1) * limit;
-    // const endRange = startRange + limit - 1;
-    // const { data, error, count } = await supabase
-    //   .from('partners')
-    //   .select('*', { count: 'exact' })
-    //   .match(query)
-    //   .range(startRange, endRange);
-    // if (data && isEmpty(data)) {
-    //   res.status(404).send(`No partners found matching query:\n${JSON.stringify(req.query)}`);
-    // } else if (error) {
-    //   res.status(400).send(error);
-    // } else {
-    //   const pages = Math.ceil(count / limit);
-    //   const payload = {
-    //     limit,
-    //     page,
-    //     pages,
-    //     page_count: data.length,
-    //     total_count: count,
-    //     data,
-    //   };
-    //   res.status(200).json(payload);
-    // }
     const { data, error } = await supabase
       .from('partners')
       .select();
-    if (data && isEmpty(data)) {
-      res.status(404).send('There were no partners found.');
-    } else if (error) {
+    if (error) {
       res.status(400).send(error);
     } else {
       res.status(200).json(data);

--- a/src/pages/api/partners/index.js
+++ b/src/pages/api/partners/index.js
@@ -1,6 +1,5 @@
 import router from 'modules/router';
 import supabase from 'modules/supabase';
-import { isEmpty, omit } from 'ramda';
 
 const api = {
   /* GET all partners

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from '@emotion/styled';
 import { Button, Snackbar } from '@material-ui/core';
 import MuiAlert from '@material-ui/lab/Alert';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -145,10 +145,10 @@ export default function Index() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-      <Container>
+      {/* <Container>
         <H1>Ministers</H1>
         <Ministers />
-      </Container>
+      </Container> */}
 
       {/* <Container>
         <H1>Partners</H1>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -150,10 +150,10 @@ export default function Index() {
         <Ministers />
       </Container>
 
-      <Container>
+      {/* <Container>
         <H1>Partners</H1>
         <Partners />
-      </Container>
+      </Container> */}
 
       <Container>
         <H1>Get Minister By ID</H1>


### PR DESCRIPTION
closes #42 

- Changed API route for getting partners to return all instead of paginate results. Will need to hande pagination in client.
- Commented out the `Partners` and `Ministers` components on root `index.js` page because it no longer works with API changes.